### PR TITLE
Localize "Table of Contents" on toc.html template file

### DIFF
--- a/templates/toc.html
+++ b/templates/toc.html
@@ -66,7 +66,7 @@ layout: default
 
 <div class="content">
 
-  <h1>Table of Contents</h1>
+  <h1>{% localize global.toc %}</h1>
   
   <ul id="toc">
     <li>


### PR DESCRIPTION
The string "Table of Contents" on toc.html template file was not localized. I've changed to use the global.toc translation
