### PR TITLE
Ads: Switch to Bocoup's Revive ad server tag

### DIFF
--- a/templates/_layouts/default.html
+++ b/templates/_layouts/default.html
@@ -102,17 +102,24 @@
     </div>
     <div id="advertisements">
       <span>Ads by <a href="http://bocoup.com">Bocoup</a></span>
-      <script type="text/javascript">var p="http",d="static";if(document.location.protocol=="https:"){p+="s";d="engine";}var z=document.createElement("script");z.type="text/javascript";z.async=true;z.src=p+"://"+d+".adzerk.net/ados.js";var s=document.getElementsByTagName("script")[0];s.parentNode.insertBefore(z,s);</script>
-      <script type="text/javascript">
-        var ados = ados || {};
-        ados.run = ados.run || [];
-        ados.run.push(function() {
-          /* load placement for account: Bocoup, site: Learn Layout, size: 0x0 - Static Text Link*/
-          ados_add_placement(4433, 27632, "azk92758", 20);
-          ados_load();
-        });
-      </script>
-      <div id="azk92758"></div>
+      <div>
+        <!--/* Revive Adserver Javascript Tag v3.0.5 */-->
+        <script type='text/javascript'><!--//<![CDATA[
+          var m3_u = (location.protocol=='https:'?'https://revive.bocoup.com/www/delivery/ajs.php':'http://revive.bocoup.com/www/delivery/ajs.php');
+            var m3_r = Math.floor(Math.random()*99999999999);
+            if (!document.MAX_used) document.MAX_used = ',';
+            document.write ("<scr"+"ipt type='text/javascript' src='"+m3_u);
+            document.write ("?zoneid=4");
+            document.write ('&amp;cb=' + m3_r);
+            if (document.MAX_used != ',') document.write ("&amp;exclude=" + document.MAX_used);
+            document.write (document.charset ? '&amp;charset='+document.charset : (document.characterSet ? '&amp;charset='+document.characterSet : ''));
+            document.write ("&amp;loc=" + escape(window.location));
+            if (document.referrer) document.write ("&amp;referer=" + escape(document.referrer));
+            if (document.context) document.write ("&context=" + escape(document.context));
+            if (document.mmm_fo) document.write ("&amp;mmm_fo=1");
+            document.write ("'><\/scr"+"ipt>");
+            //]]>--></script><noscript><a href='http://revive.bocoup.com/www/delivery/ck.php?n=a9ab3fcf&amp;cb=INSERT_RANDOM_NUMBER_HERE' target='_blank'><img src='http://revive.bocoup.com/www/delivery/avw.php?zoneid=4&amp;cb=INSERT_RANDOM_NUMBER_HERE&amp;n=a9ab3fcf' border='0' alt='' /></a></noscript>
+      </div>
     </div>
 
   </body>

--- a/templates/css/style.css
+++ b/templates/css/style.css
@@ -355,10 +355,10 @@ footer {
   margin: 0;
 }
 
-#advertisements iframe {
-  width: 370px;
-  height: 4em;
+#advertisements div {
+  font-size: 13px;
 }
+
 
 @media screen and (min-width:601px) {
 


### PR DESCRIPTION
Adzerk is switching their pricing model and Bocoup is moving away to our own self-hosted [Revive](http://www.revive-adserver.com/) server. This pull request updates the ad tag code to one from the new Revive server. All of the same text ads are in the rotation. The main difference here is that the ads are no longer served in an `iframe`, which means been able to remove a lot of the crud from the text ads (loading the css, inline styles) and just style the ad content with the normal style.css
