### PR TITLE
Restore syntax highlight settings

### DIFF
--- a/templates/css/style.css
+++ b/templates/css/style.css
@@ -165,7 +165,7 @@ h1.content {
   direction: ltr;
 }
 
-.css, .html {
+.language-css, .language-html {
   display: block;
   text-shadow: 1px 1px 0 black;
   background-color: #333333;
@@ -183,7 +183,7 @@ h1.content {
   white-space: pre;
 }
 
-.html:before {
+.language-html:before {
   content: "html";
   float: right;
   color: black;
@@ -191,7 +191,7 @@ h1.content {
   font-size: 1.5em;
 }
 
-.css:before {
+.language-css:before {
   content: "css";
   float: right;
   color: black;
@@ -339,7 +339,7 @@ footer {
 }
 
 #share #license {
-  
+
 }
 
 #advertisements {
@@ -415,7 +415,7 @@ footer {
 
 }
 
-@media screen and (max-width:404px) { 
+@media screen and (max-width:404px) {
 
   a.nav {
     width: 40%;


### PR DESCRIPTION
Closes #123

pygments got updated in the go on easy_install/pip to version 2 and
now uses class="language-html" instead of class="html", the same
for css syntax.