### PR TITLE
fix localization plugin caching issue for page titles

### DIFF
--- a/_plugins/localize.rb
+++ b/_plugins/localize.rb
@@ -24,7 +24,13 @@ module Jekyll
           @key = @key[token]
         end
       end
-      
+
+      # hacky fix for liquid caching issue
+      # see https://github.com/incompl/csslayoutsite/issues/155)
+      if @key.include?(".title") && !@key.include?("global")
+        @key = context.registers[:page]["title"]
+      end
+
       result = @translations[@key]
 
       if result.nil? and defined? @defaults


### PR DESCRIPTION
Fixes https://github.com/incompl/csslayoutsite/issues/155, at least temporarily.

Somewhat hacky workaround for caching issue that's leading to incorrect page titles.

Adding something like https://github.com/jekyll/jekyll/pull/7967/files adds, but resetting `@template.registers`, would probably be a long-term fix. Like most caching issues, clearing the cache probably would result in a speed hit for the general use case. I don't know enough about liquid to know how to ask to recompute for passing a value into a tag; the template is otherwise getting the correct values (e.g. for the next and prev button urls).